### PR TITLE
chore: add GitHub Action that tries to build all projects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Check everything builds
-on: [push]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,14 @@
+name: Check everything builds
+on: [push]
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install 🔧
+        run: yarn
+
+      - name: Attempt to build
+        run: yarn build:all

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0",
   "license": "MIT",
   "scripts": {
+    "build:all": "nx run-many --target=build",
     "dev:all": "nx run-many --target=serve --projects=react-trrack-example,rtk-trrack-example --output-style=stream",
     "test:all:watch": "nx run-many --target=test --projects=core,redux --watch",
     "prepare": "husky install",


### PR DESCRIPTION
This adds a GitHub Action that attempts to build all projects.

This would highlight problems like the type errors that currently prevent the examples from running (e.g., Issue #15).