### PR TITLE
fix(core): fixed readonly bug during patch apply

### DIFF
--- a/packages/core/src/provenance/trrack.ts
+++ b/packages/core/src/provenance/trrack.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { PayloadAction } from '@reduxjs/toolkit';
-import { applyPatch, compare, Operation } from 'fast-json-patch';
+import { applyPatch, compare, deepClone, Operation } from 'fast-json-patch';
 
 import { initEventManager } from '../event';
 import {
@@ -49,7 +49,14 @@ function getState<State, Event extends string>(
 
     const checkpointState = getState(checkpointNode, nodes);
 
-    return applyPatch(checkpointState, patches, true, false).newDocument;
+    const results = applyPatch(
+        checkpointState,
+        deepClone(patches),
+        true,
+        false
+    );
+
+    return results.newDocument;
 }
 
 function determineSaveStrategy<T>(


### PR DESCRIPTION
Trrack stores diffs between state as patches, and the issue arises when applying the patches. Say if patch A contains a complex object, and patch B changes one of the keys, when trrack tries to apply patch B after patch A it runs into readonly error. This happens because patches are readonly.