### PR TITLE
Full support for metadata & artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@typescript-eslint/parser": "5.42.0",
     "@vitejs/plugin-react": "^3.0.1",
     "@vitest/coverage-c8": "~0.25.8",
-    "@vitest/ui": "^0.25.8",
+    "@vitest/ui": "^0.29.2",
     "commitizen": "^4.3.0",
     "css-loader": "^6.4.0",
     "eslint": "8.15.0",

--- a/packages/core/project.json
+++ b/packages/core/project.json
@@ -41,6 +41,12 @@
             "options": {
                 "passWithNoTests": true,
                 "reportsDirectory": "../../coverage/packages/core"
+            },
+            "configurations": {
+                "dev": {
+                    "watch": true,
+                    "ui": true
+                }
             }
         },
         "lint": {

--- a/packages/core/src/graph/components/node.ts
+++ b/packages/core/src/graph/components/node.ts
@@ -20,124 +20,142 @@ type Patches = {
 export type StateLike<State> = Checkpoint<State> | Patches;
 
 /**
+ * Node Artifact Type
+ */
+
+/**
  * Artifact Types
  */
 export type ArtifactId = FlavoredId<string, 'Artifact'>;
 
-export type BaseArtifactType<A> = {
+export type NodeArtifact = Array<{
     id: ArtifactId;
     createdOn: number;
-    val: A;
-};
+    val: unknown;
+}>;
 
 /**
  * Node Metadata Type
  */
-type NodeMetadata<Event extends string = any> = {
+export type MetadataId = FlavoredId<string, 'Metadata'>;
+
+type MetadataShape<T> = {
+    id: MetadataId;
+    type: string;
     createdOn: number;
-    eventType: Event | 'Root';
-    [key: string]: any;
+    val: T;
+};
+
+type NodeMetadata = {
+    annotation: Array<MetadataShape<string>>;
+    bookmark: Array<MetadataShape<boolean>>;
+    [key: string]: Array<MetadataShape<unknown>>;
 };
 
 /**
  * Node Types
  */
-type BaseNode<State, Event extends string> = {
+type BaseNode<State> = {
+    label: string;
     id: NodeId;
-    meta: NodeMetadata<Event>;
+    createdOn: number;
+    artifacts: NodeArtifact;
+    meta: NodeMetadata;
     children: NodeId[];
     state: StateLike<State>;
     level: number;
 };
 
-export type RootNode<
-    State = any,
-    Event extends string = any,
-    Artifact extends BaseArtifactType<any> = any
-> = BaseNode<State, Event> & {
-    label: string;
-    artifact?: Artifact;
-};
+export type RootNode<State> = BaseNode<State> & { event: 'Root' };
 
 export type SideEffects = {
     do: Array<PayloadAction<any, any>>;
     undo: Array<PayloadAction<any, any>>;
 };
 
-export type StateNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
-> = RootNode<State, Event, Artifact> & {
+export type StateNode<State, Event extends string> = BaseNode<State> & {
+    event: Event;
     parent: NodeId;
     sideEffects: SideEffects;
 };
 
-export type ProvenanceNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
-> = RootNode<State, Event, Artifact> | StateNode<State, Event, Artifact>;
+export type ProvenanceNode<State, Event extends string> =
+    | RootNode<State>
+    | StateNode<State, Event>;
 
-export type Nodes<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
-> = Record<string, ProvenanceNode<State, Event, Artifact>>;
+export type Nodes<State, Event extends string> = Record<
+    string,
+    ProvenanceNode<State, Event>
+>;
 
-export function isStateNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
->(
-    node: ProvenanceNode<State, Event, Artifact>
-): node is StateNode<State, Event, Artifact> {
+export function isStateNode<State, Event extends string>(
+    node: ProvenanceNode<State, Event>
+): node is StateNode<State, Event> {
     return 'parent' in node;
 }
 
-export function isRootNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
->(
-    node: ProvenanceNode<State, Event, Artifact>
-): node is RootNode<State, Event, Artifact> {
+export function isRootNode<State, Event extends string>(
+    node: ProvenanceNode<State, Event>
+): node is RootNode<State> {
     return !isStateNode(node);
 }
 
-export function createRootNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
->(args: {
+export function createRootNode<State>(args: {
     state: State;
-    artifact?: Artifact;
+    initialMetadata?: Record<string, unknown>;
+    initialArtifact?: unknown;
     label?: string;
-}): RootNode<State, Event, Artifact> {
-    const { label = undefined, state, artifact } = args;
+}): RootNode<State> {
+    const { label = undefined, state, initialArtifact, initialMetadata } = args;
+
+    const commonMetadata: NodeMetadata = {
+        annotation: [],
+        bookmark: [],
+    };
+
+    const meta = Object.keys(initialMetadata || {}).reduce<NodeMetadata>(
+        (acc: NodeMetadata, key) => {
+            acc[key] = [];
+            if (initialMetadata && initialMetadata[key]) {
+                acc[key].push({
+                    type: key,
+                    id: ID.get(),
+                    val: initialMetadata[key],
+                    createdOn: Date.now(),
+                });
+            }
+            return acc;
+        },
+        commonMetadata
+    );
+
+    const artifacts = initialArtifact
+        ? [
+              {
+                  id: ID.get(),
+                  createdOn: Date.now(),
+                  val: initialArtifact,
+              },
+          ]
+        : [];
 
     return {
         id: ID.get(),
         label: label || 'Root',
+        event: 'Root',
         children: [],
         level: 0,
-        meta: {
-            createdOn: Date.now(),
-            eventType: 'Root',
-        },
+        createdOn: Date.now(),
+        meta,
+        artifacts,
         state: {
             type: 'checkpoint',
             val: state,
         },
-        artifact,
     };
 }
 
-export function createStateNode<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
->({
+export function createStateNode<State, Event extends string>({
     parent,
     state,
     label,
@@ -145,28 +163,60 @@ export function createStateNode<
         do: [],
         undo: [],
     },
-    artifact = undefined,
-    eventType,
+    initialMetadata,
+    initialArtifact,
+    event,
 }: {
-    parent: ProvenanceNode<State, Event, Artifact>;
+    parent: ProvenanceNode<State, Event>;
     state: StateLike<State>;
+    initialMetadata?: Record<string, unknown>;
+    initialArtifact?: unknown;
     label: string;
     sideEffects?: SideEffects;
-    artifact?: Artifact;
-    eventType: Event;
-}): StateNode<State, Event, Artifact> {
+    event: Event;
+}): StateNode<State, Event> {
+    const commonMetadata: NodeMetadata = {
+        annotation: [],
+        bookmark: [],
+    };
+
+    const meta = Object.keys(initialMetadata || {}).reduce<NodeMetadata>(
+        (acc: NodeMetadata, key) => {
+            acc[key] = [];
+            if (initialMetadata && initialMetadata[key]) {
+                acc[key].push({
+                    type: key,
+                    id: ID.get(),
+                    val: initialMetadata[key],
+                    createdOn: Date.now(),
+                });
+            }
+            return acc;
+        },
+        commonMetadata
+    );
+
+    const artifacts = initialArtifact
+        ? [
+              {
+                  id: ID.get(),
+                  createdOn: Date.now(),
+                  val: initialArtifact,
+              },
+          ]
+        : [];
+
     return {
         id: ID.get(),
         label,
+        event,
         children: [],
         parent: parent.id,
-        meta: {
-            createdOn: Date.now(),
-            eventType: eventType,
-        },
+        createdOn: Date.now(),
+        meta,
+        artifacts,
         sideEffects,
         state,
         level: parent.level + 1,
-        artifact,
     };
 }

--- a/packages/core/src/graph/components/node.ts
+++ b/packages/core/src/graph/components/node.ts
@@ -28,18 +28,20 @@ export type StateLike<State> = Checkpoint<State> | Patches;
  */
 export type ArtifactId = FlavoredId<string, 'Artifact'>;
 
-export type NodeArtifact = Array<{
+export type Artifact = {
     id: ArtifactId;
     createdOn: number;
     val: unknown;
-}>;
+};
+
+export type NodeArtifact = Array<Artifact>;
 
 /**
  * Node Metadata Type
  */
 export type MetadataId = FlavoredId<string, 'Metadata'>;
 
-type MetadataShape<T> = {
+export type Metadata<T = unknown> = {
     id: MetadataId;
     type: string;
     createdOn: number;
@@ -47,9 +49,9 @@ type MetadataShape<T> = {
 };
 
 type NodeMetadata = {
-    annotation: Array<MetadataShape<string>>;
-    bookmark: Array<MetadataShape<boolean>>;
-    [key: string]: Array<MetadataShape<unknown>>;
+    annotation: Array<Metadata<string>>;
+    bookmark: Array<Metadata<boolean>>;
+    [key: string]: Array<Metadata<unknown>>;
 };
 
 /**

--- a/packages/core/src/graph/graph-slice.ts
+++ b/packages/core/src/graph/graph-slice.ts
@@ -1,32 +1,57 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, PayloadAction, Slice } from '@reduxjs/toolkit';
 
-import { BaseArtifactType, createRootNode, NodeId, Nodes, StateNode } from './components';
+import { castDraft } from 'immer';
+import { ID } from '../utils';
+import { createRootNode, NodeId, Nodes, StateNode } from './components';
 
-export type ProvenanceGraph<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
-> = {
-    nodes: Nodes<State, Event, Artifact>;
+type AddMetadataPayload = {
+    id: NodeId;
+    meta: Record<string, unknown>;
+};
+
+type AddArtifactPayload = {
+    id: NodeId;
+    artifact: unknown;
+};
+
+export type ProvenanceGraph<State, Event extends string> = {
+    nodes: Nodes<State, Event>;
     current: NodeId;
     root: NodeId;
 };
 
+type GraphSlice<S, E extends string> = Slice<ProvenanceGraph<S, E>>;
+
+export type ProvenanceGraphActions<S, E extends string> = GraphSlice<
+    S,
+    E
+>['actions'];
+
 // Maybe swithc to reduxtoolkit createEntityAdapter
 
-export function graphSliceCreator<
-    State,
-    Event extends string,
-    Artifact extends BaseArtifactType<any>
->(initialState: State, rootArtifact?: Artifact) {
-    const root = createRootNode<State, Event, Artifact>({
+export function graphSliceCreator<State, Event extends string>(
+    initialState: State,
+    args: {
+        artifact?: unknown;
+        metadata?: Record<string, unknown>;
+        rootLabel?: string;
+    } = {}
+) {
+    const {
+        artifact = undefined,
+        metadata = undefined,
+        rootLabel = 'Root',
+    } = args;
+
+    const root = createRootNode<State>({
         state: initialState,
-        label: 'Root' as Event,
-        artifact: rootArtifact,
+        label: rootLabel,
+        initialArtifact: artifact,
+        initialMetadata: metadata,
     });
 
-    const graph: ProvenanceGraph<State, Event, Artifact> = {
+    const graph: ProvenanceGraph<State, Event> = {
         nodes: {
             [root.id]: root,
         },
@@ -34,24 +59,50 @@ export function graphSliceCreator<
         current: root.id,
     };
 
-    return createSlice({
+    const slice = createSlice({
         name: 'provenance-graph',
         initialState: graph,
         reducers: {
+            addMetadata(g, action: PayloadAction<AddMetadataPayload>) {
+                const { id, meta } = action.payload;
+                const existingMetadata = g.nodes[id].meta;
+
+                const metaData = Object.keys(meta).reduce((acc, key) => {
+                    if (!acc[key]) {
+                        acc[key] = [];
+                    }
+                    acc[key].push({
+                        type: key,
+                        id: ID.get(),
+                        val: meta[key],
+                        createdOn: Date.now(),
+                    });
+
+                    return acc;
+                }, existingMetadata);
+
+                g.nodes[action.payload.id].meta = metaData;
+            },
+            addArtifact(g, action: PayloadAction<AddArtifactPayload>) {
+                g.nodes[action.payload.id].artifacts.push({
+                    id: ID.get(),
+                    createdOn: Date.now(),
+                    val: castDraft(action.payload.artifact),
+                });
+            },
             changeCurrent(g, action: PayloadAction<NodeId>) {
                 g.current = action.payload;
             },
-            addNode(
-                g,
-                { payload }: PayloadAction<StateNode<State, Event, Artifact>>
-            ) {
+            addNode(g, { payload }: PayloadAction<StateNode<State, Event>>) {
                 g.nodes[payload.id] = payload as any;
                 g.nodes[payload.parent].children.push(payload.id);
                 g.current = payload.id;
             },
-            load(_, {payload}: PayloadAction<ProvenanceGraph<State, Event, Artifact>>) {
+            load(_, { payload }: PayloadAction<ProvenanceGraph<State, Event>>) {
                 return payload;
-            }
+            },
         },
     });
+
+    return slice;
 }

--- a/packages/core/src/graph/provenance-graph.ts
+++ b/packages/core/src/graph/provenance-graph.ts
@@ -17,7 +17,13 @@ export type CurrentChangeHandlerConfig = {
 };
 export type UnsubscribeCurrentChangeListener = () => boolean;
 
-export function initializeProvenanceGraph<S>(initialState: S) {
+export type ProvenanceGraphStore = ReturnType<typeof f>;
+
+const f = () => initializeProvenanceGraph<any, any>({});
+
+export function initializeProvenanceGraph<State, Event extends string>(
+    initialState: State
+) {
     const listeners: Map<
         string,
         {
@@ -27,8 +33,10 @@ export function initializeProvenanceGraph<S>(initialState: S) {
         }
     > = new Map();
 
-    const { reducer, actions, getInitialState } =
-        graphSliceCreator(initialState);
+    const { reducer, actions, getInitialState } = graphSliceCreator<
+        State,
+        Event
+    >(initialState);
 
     const listenerMiddleware = createListenerMiddleware();
 
@@ -62,7 +70,9 @@ export function initializeProvenanceGraph<S>(initialState: S) {
             return store.getState().nodes[store.getState().current];
         },
         get root() {
-            return store.getState().nodes[store.getState().root] as RootNode<S>;
+            return store.getState().nodes[
+                store.getState().root
+            ] as RootNode<State>;
         },
         currentChange(
             func: CurrentChangeHandler,

--- a/packages/core/src/provenance/index.ts
+++ b/packages/core/src/provenance/index.ts
@@ -1,3 +1,4 @@
 export * from './trrack';
-export * from './trrack-events';
 export * from './trrack-config-opts';
+export * from './trrack-events';
+export * from './types';

--- a/packages/core/src/provenance/trrack-config-opts.ts
+++ b/packages/core/src/provenance/trrack-config-opts.ts
@@ -1,6 +1,6 @@
 import { Registry } from '../registry/reg';
 
-export type ConfigureTrrackOptions<S> = {
-    registry: Registry<any>;
+export type ConfigureTrrackOptions<S, E extends string = any> = {
+    registry: Registry<E>;
     initialState: S;
 };

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -1,0 +1,46 @@
+import { PayloadAction } from '@reduxjs/toolkit';
+import { NodeId } from '@trrack/core';
+import {
+    CurrentChangeHandler,
+    ProvenanceGraphStore,
+    ProvenanceNode,
+    RootNode,
+    SideEffects,
+    UnsubscribeCurrentChangeListener,
+} from '../graph';
+import { Registry } from '../registry';
+import { TrrackEvents } from './trrack-events';
+
+export type RecordActionArgs<State, Event extends string> = {
+    label: string;
+    state: State;
+    eventType: Event;
+    sideEffects: SideEffects;
+    onlySideEffects?: boolean;
+};
+
+export interface Trrack<State, Event extends string> {
+    registry: Registry<Event>;
+    isTraversing: boolean;
+    getState(node?: ProvenanceNode<State, Event>): State;
+    graph: ProvenanceGraphStore;
+    current: ProvenanceNode<State, Event>;
+    root: RootNode<State>;
+    record(args: RecordActionArgs<State, Event>): void;
+    apply<T extends string, Payload = any>(
+        label: string,
+        act: PayloadAction<Payload, T>
+    ): any;
+    to(node: NodeId): Promise<void>;
+    undo(): Promise<void>;
+    redo(to?: 'latest' | 'oldest'): Promise<void>;
+    currentChange(
+        listener: CurrentChangeHandler,
+        skipOnNew?: boolean
+    ): UnsubscribeCurrentChangeListener;
+    done(): void;
+    tree(): any;
+    on(event: TrrackEvents, listener: (args?: any) => void): void;
+    export(): string;
+    import(graphString: string): void;
+}

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -1,7 +1,9 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 import { NodeId } from '@trrack/core';
 import {
+    Artifact,
     CurrentChangeHandler,
+    Metadata,
     ProvenanceGraphStore,
     ProvenanceNode,
     RootNode,
@@ -32,6 +34,36 @@ export interface Trrack<State, Event extends string> {
         act: PayloadAction<Payload, T>
     ): any;
     to(node: NodeId): Promise<void>;
+    metadata: {
+        add(metadata: Record<string, unknown>, node?: NodeId): void;
+        latestOfType<T = unknown>(
+            type: string,
+            node?: NodeId
+        ): Metadata<T> | undefined;
+        allOfType<T = unknown>(
+            type: string,
+            node?: NodeId
+        ): Metadata<T>[] | undefined;
+        latest(node?: NodeId): Record<string, Metadata> | undefined;
+        all(node?: NodeId): Record<string, Metadata[]> | undefined;
+        types(node?: NodeId): string[];
+    };
+    artifact: {
+        add<A>(artifact: A, node?: NodeId): void;
+        latest(node?: NodeId): Artifact | undefined;
+        all(node?: NodeId): Artifact[] | undefined;
+    };
+    annotations: {
+        add(annotation: string, node?: NodeId): void;
+        latest(node?: NodeId): string | undefined;
+        all(node?: NodeId): string[] | undefined;
+    };
+    bookmarks: {
+        add(node?: NodeId): void;
+        remove(node?: NodeId): void;
+        is(node?: NodeId): boolean;
+        toggle(node?: NodeId): void;
+    };
     undo(): Promise<void>;
     redo(to?: 'latest' | 'oldest'): Promise<void>;
     currentChange(

--- a/packages/core/tests/event.spec.ts
+++ b/packages/core/tests/event.spec.ts
@@ -1,73 +1,68 @@
-describe('Placeholder test', () => {
-    it('should pass', () => {
-        expect(true).toBeTruthy();
+import { initEventManager } from '../src/event/index';
+describe('Event Manager', () => {
+    it('should create an instance of EventManager', () => {
+        const eventManager = initEventManager();
+
+        expect(eventManager).toBeDefined();
+        expect(eventManager).toHaveProperty('listen');
+        expect(typeof eventManager.listen).toBe('function');
+
+        expect(eventManager).toHaveProperty('fire');
+        expect(typeof eventManager.fire).toBe('function');
+    });
+
+    it('should attach event listener and trigger without arguments', () => {
+        const eventManager = initEventManager();
+
+        const EVENT = 'test';
+
+        let count = 0;
+
+        const handler = vi.fn(() => {
+            count = count + 1;
+        });
+
+        eventManager.listen(EVENT, handler);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(count).toBe(0);
+
+        eventManager.fire(EVENT);
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(count).toBe(1);
+
+        eventManager.fire(EVENT);
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(count).toBe(2);
+    });
+
+    it('should attach event listener and trigger with arguments', () => {
+        const eventManager = initEventManager();
+
+        const EVENT = 'test';
+
+        const arr: string[] = [];
+
+        const ARG1 = 'Test 1';
+        const ARG2 = 'Test 2';
+
+        const handler = vi.fn((toAdd: string) => {
+            arr.push(toAdd);
+        });
+
+        eventManager.listen(EVENT, handler);
+
+        expect(handler).not.toHaveBeenCalled();
+        expect(arr.length).toBe(0);
+
+        eventManager.fire(EVENT, ARG1);
+        expect(handler).toHaveBeenCalledTimes(1);
+        expect(arr.length).toBe(1);
+        expect(arr).toContain(ARG1);
+
+        eventManager.fire(EVENT, ARG2);
+        expect(handler).toHaveBeenCalledTimes(2);
+        expect(arr.length).toBe(2);
+        expect(arr).toContain(ARG2);
     });
 });
-
-// describe('Event Manager', () => {
-//     it('should create an instance of EventManager', () => {
-//         const eventManager = initEventManager();
-
-//         expect(eventManager).toBeDefined();
-//         expect(eventManager).toHaveProperty('listen');
-//         expect(typeof eventManager.listen).toBe('function');
-
-//         expect(eventManager).toHaveProperty('fire');
-//         expect(typeof eventManager.fire).toBe('function');
-//     });
-
-//     it('should attach event listener and trigger without arguments', () => {
-//         const eventManager = initEventManager();
-
-//         const EVENT = 'test';
-
-//         let count = 0;
-
-//         const handler = vi.fn(() => {
-//             count = count + 1;
-//         });
-
-//         eventManager.listen(EVENT, handler);
-
-//         expect(handler).not.toHaveBeenCalled();
-//         expect(count).toBe(0);
-
-//         eventManager.fire(EVENT);
-//         expect(handler).toHaveBeenCalledTimes(1);
-//         expect(count).toBe(1);
-
-//         eventManager.fire(EVENT);
-//         expect(handler).toHaveBeenCalledTimes(2);
-//         expect(count).toBe(2);
-//     });
-
-//     it('should attach event listener and trigger with arguments', () => {
-//         const eventManager = initEventManager();
-
-//         const EVENT = 'test';
-
-//         const arr: string[] = [];
-
-//         const ARG1 = 'Test 1';
-//         const ARG2 = 'Test 2';
-
-//         const handler = vi.fn((toAdd: string) => {
-//             arr.push(toAdd);
-//         });
-
-//         eventManager.listen(EVENT, handler);
-
-//         expect(handler).not.toHaveBeenCalled();
-//         expect(arr.length).toBe(0);
-
-//         eventManager.fire(EVENT, ARG1);
-//         expect(handler).toHaveBeenCalledTimes(1);
-//         expect(arr.length).toBe(1);
-//         expect(arr).toContain(ARG1);
-
-//         eventManager.fire(EVENT, ARG2);
-//         expect(handler).toHaveBeenCalledTimes(2);
-//         expect(arr.length).toBe(2);
-//         expect(arr).toContain(ARG2);
-//     });
-// });

--- a/packages/core/tests/metadata-artifact.spec.ts
+++ b/packages/core/tests/metadata-artifact.spec.ts
@@ -1,0 +1,245 @@
+import { initializeTrrack } from '../src/provenance/trrack';
+import { Registry } from '../src/registry';
+function setup() {
+    const registry = Registry.create();
+
+    const add = registry.register('add', (state, amt) => {
+        state.counter += amt;
+    });
+
+    const sub = registry.register('sub', (state, amt) => {
+        state.counter -= amt;
+    });
+
+    const trrack = initializeTrrack({
+        registry,
+        initialState: {
+            counter: 0,
+        },
+    });
+
+    return { trrack, add, sub };
+}
+
+describe('Artifacts', () => {
+    it('artifacts should be undefined if not set', () => {
+        const { trrack } = setup();
+
+        expect(trrack.artifact.latest()).toBeUndefined();
+    });
+
+    it('should be able to create an artifact on root', () => {
+        const { trrack } = setup();
+
+        const artifact = {
+            file: 'url-to-file',
+        };
+
+        trrack.artifact.add(artifact);
+        expect(trrack.artifact.latest()?.val).toStrictEqual(artifact);
+    });
+
+    it('should be able to add artifacts on node', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const artifact = {
+            file: 'url-to-file',
+        };
+
+        trrack.artifact.add(artifact);
+        expect(trrack.artifact.latest()?.val).toStrictEqual(artifact);
+        expect(
+            trrack.artifact.latest((trrack.current as any).parent)?.val
+        ).toBeUndefined();
+    });
+
+    it('should be able to add and get multiple artifacts', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const artifact1 = {
+            file: 'url-to-file',
+        };
+
+        const artifact2 = {
+            file: 'url-to-file2',
+        };
+
+        trrack.artifact.add(artifact1);
+        trrack.artifact.add(artifact2);
+
+        expect(trrack.artifact.all()?.length).toBe(2);
+        expect(trrack.artifact.all()?.map((a) => a.val)).toContain(artifact1);
+        expect(trrack.artifact.all()?.map((a) => a.val)).toContain(artifact2);
+    });
+});
+
+describe('Metadata', () => {
+    const METADATA_TYPE_1 = 'test';
+    const METADATA_TYPE_2 = 'test2';
+
+    it('metadata of a type should be undefined if not set', () => {
+        const { trrack } = setup();
+
+        expect(trrack.metadata.latestOfType(METADATA_TYPE_1)).toBeUndefined();
+    });
+
+    it('should be able to create metadata on root', () => {
+        const { trrack } = setup();
+
+        const metadata = {
+            [METADATA_TYPE_1]: Date.now(),
+        };
+
+        trrack.metadata.add(metadata);
+        expect(
+            trrack.metadata.latestOfType(METADATA_TYPE_1)?.val
+        ).toStrictEqual(metadata[METADATA_TYPE_1]);
+    });
+
+    it('should be able to add metadata on node', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const metadata = {
+            [METADATA_TYPE_1]: Date.now(),
+        };
+
+        trrack.metadata.add(metadata);
+        expect(
+            trrack.metadata.latestOfType(METADATA_TYPE_1)?.val
+        ).toStrictEqual(metadata[METADATA_TYPE_1]);
+        expect(
+            trrack.metadata.latestOfType(
+                METADATA_TYPE_1,
+                (trrack.current as any).parent
+            )?.val
+        ).toBeUndefined();
+    });
+
+    it('should be able to add and get multiple types and counts of metadatas', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const metadata1 = {
+            [METADATA_TYPE_1]: Date.now() + METADATA_TYPE_1,
+            [METADATA_TYPE_2]: Date.now() + METADATA_TYPE_2,
+        };
+
+        const metadata2 = {
+            [METADATA_TYPE_1]: Date.now() + METADATA_TYPE_1 + 1,
+        };
+
+        trrack.metadata.add(metadata1);
+        expect(trrack.metadata.latestOfType(METADATA_TYPE_1)?.val).toContain(
+            metadata1[METADATA_TYPE_1]
+        );
+        expect(trrack.metadata.latestOfType(METADATA_TYPE_2)?.val).toContain(
+            metadata1[METADATA_TYPE_2]
+        );
+
+        trrack.metadata.add(metadata2);
+
+        expect(trrack.metadata.allOfType(METADATA_TYPE_1)?.length).toBe(2);
+        expect(trrack.metadata.latestOfType(METADATA_TYPE_1)?.val).toContain(
+            metadata2[METADATA_TYPE_1]
+        );
+        expect(trrack.metadata.latestOfType(METADATA_TYPE_2)?.val).toContain(
+            metadata1[METADATA_TYPE_2]
+        );
+    });
+});
+
+describe('Annotations', () => {
+    it('annotations should be undefined if not set', () => {
+        const { trrack } = setup();
+
+        expect(trrack.annotations.latest()).toBeUndefined();
+    });
+
+    it('should be able to create annotation on root', () => {
+        const { trrack } = setup();
+
+        const ann = Date.now().toString();
+
+        trrack.annotations.add(ann);
+        expect(trrack.annotations.latest()).toStrictEqual(ann);
+    });
+
+    it('should be able to add annotation on node', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const ann = Date.now().toString();
+
+        trrack.annotations.add(ann);
+        expect(trrack.annotations.latest()).toStrictEqual(ann);
+
+        expect(
+            trrack.annotations.latest((trrack.current as any).parent)
+        ).toBeUndefined();
+    });
+
+    it('should be able to add and get multiple annotations', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        const ann = Date.now().toString();
+        const ann2 = Date.now().toString() + 2;
+
+        trrack.annotations.add(ann);
+        expect(trrack.annotations.latest()).toStrictEqual(ann);
+
+        trrack.annotations.add(ann2);
+        expect(trrack.annotations.all()?.length).toBe(2);
+        expect(trrack.annotations.all()).toContain(ann);
+        expect(trrack.annotations.all()).toContain(ann2);
+    });
+});
+
+describe('Bookmarks', () => {
+    it('bookmark should return false if not set', () => {
+        const { trrack } = setup();
+
+        expect(trrack.bookmarks.is()).toBeFalsy();
+    });
+
+    it('should be able to add bookmark on root', () => {
+        const { trrack } = setup();
+
+        trrack.bookmarks.add();
+        expect(trrack.bookmarks.is()).toBeTruthy();
+    });
+
+    it('should be able to add/remove bookmark on node', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        trrack.bookmarks.add();
+        expect(trrack.bookmarks.is()).toBeTruthy();
+
+        trrack.bookmarks.remove();
+        expect(trrack.bookmarks.is()).toBeFalsy();
+    });
+
+    it('should be able to toggle bookmarks', () => {
+        const { trrack, add } = setup();
+
+        trrack.apply('add', add(3));
+
+        trrack.bookmarks.add();
+        trrack.bookmarks.toggle();
+        expect(trrack.bookmarks.is()).toBeFalsy();
+
+        trrack.bookmarks.toggle();
+        expect(trrack.bookmarks.is()).toBeTruthy();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4554,11 +4554,15 @@
   dependencies:
     tinyspy "^1.0.2"
 
-"@vitest/ui@^0.25.8":
-  version "0.25.8"
-  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-0.25.8.tgz#c97f25cd5ca8e9c0294326657420c9a047540297"
-  integrity sha512-wfuhghldD5QHLYpS46GK8Ru8P3XcMrWvFjRQD21KNzc9Y/qtJsqoC8KmT6xWVkMNw4oHYixpo3a4ZySRJdserw==
+"@vitest/ui@^0.29.2":
+  version "0.29.2"
+  resolved "https://registry.yarnpkg.com/@vitest/ui/-/ui-0.29.2.tgz#b5c9d6e7c98163a5136c91760a602cf61edc473b"
+  integrity sha512-GpCExCMptrS1z3Xf6kz35Xdvjc2eTBy9OIIwW3HjePVxw9Q++ZoEaIBVimRTTGzSe40XiAI/ZyR0H0Ya9brqLA==
   dependencies:
+    fast-glob "^3.2.12"
+    flatted "^3.2.7"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
     sirv "^2.0.2"
 
 "@vitest/utils@0.28.3":
@@ -8092,7 +8096,7 @@ flat@^5.0.2:
   resolved "https://registry.yarnpkg.com/flat/-/flat-5.0.2.tgz#8ca6fe332069ffa9d324c327198c598259ceb241"
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
-flatted@^3.1.0:
+flatted@^3.1.0, flatted@^3.2.7:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==


### PR DESCRIPTION
Can add/remove metadata and artifacts.

Annotations and bookmarks are default metadata. Both are wrappers over the metadata feature.

Minor changes:
Added vitest UI for testing.
Updated test command to watch and open the GUI server.
Added tests for metadata, artifact, annotations and bookmark handling.