### PR TITLE
Add API for screenshots 

### DIFF
--- a/apps/react-trrack-example/src/app/App.tsx
+++ b/apps/react-trrack-example/src/app/App.tsx
@@ -1,9 +1,11 @@
-import { Box, Checkbox, List, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import { Box, Button, Checkbox, List, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
 import Tree, { useTreeState } from 'react-hyper-tree';
 import { TreeNode } from 'react-hyper-tree/dist/helpers/node';
 
 import { Navbar } from './components/Navbar';
 import { useTrrackTaskManager } from './store/trrack';
+import { useRef } from 'react';
+import { ScreenshotStream, downloadScreenshot } from '@trrack/core';
 
 function App() {
   const trrackManager = useTrrackTaskManager();
@@ -18,9 +20,16 @@ function App() {
 
   open(required.data, trrackManager.trrack.current.id);
 
+  // Testing screenshot stream
+  const ss = useRef(new ScreenshotStream());
+
   return (
     <Box sx={{ height: '100vh', width: '100vw' }}>
-      <Navbar t={trrackManager} />
+      <Navbar t={trrackManager} ss={ss.current} />
+      <Button onClick={() => downloadScreenshot(ss.current.getNth(0), 'screenshot')}>
+        Download Latest Screenshot
+      </Button>
+      <Button onClick={() => {ss.current.start()}}>Start recording</Button>
       <Box
         sx={{
           display: 'grid',
@@ -29,7 +38,7 @@ function App() {
         }}
       >
         <List>
-          {trrackManager.state.tasks.map((task) => (
+          {trrackManager.state.tasks?.map((task) => (
             <ListItem key={task.id}>
               <ListItemIcon>
                 <Checkbox

--- a/apps/react-trrack-example/src/app/App.tsx
+++ b/apps/react-trrack-example/src/app/App.tsx
@@ -1,4 +1,13 @@
-import { Box, Button, Checkbox, List, ListItem, ListItemIcon, ListItemText, Typography } from '@mui/material';
+import {
+  Box,
+  Button,
+  Checkbox,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Typography,
+} from '@mui/material';
 import Tree, { useTreeState } from 'react-hyper-tree';
 import { TreeNode } from 'react-hyper-tree/dist/helpers/node';
 
@@ -26,10 +35,18 @@ function App() {
   return (
     <Box sx={{ height: '100vh', width: '100vw' }}>
       <Navbar t={trrackManager} ss={ss.current} />
-      <Button onClick={() => downloadScreenshot(ss.current.getNth(0), 'screenshot')}>
+      <Button
+        onClick={() => downloadScreenshot(ss.current.getNth(0), 'screenshot')}
+      >
         Download Latest Screenshot
       </Button>
-      <Button onClick={() => {ss.current.start()}}>Start recording</Button>
+      <Button
+        onClick={() => {
+          ss.current.start();
+        }}
+      >
+        Start recording
+      </Button>
       <Box
         sx={{
           display: 'grid',

--- a/apps/react-trrack-example/src/app/App.tsx
+++ b/apps/react-trrack-example/src/app/App.tsx
@@ -34,7 +34,11 @@ function App() {
   return (
     <Box sx={{ height: '100vh', width: '100vw' }}>
       <Navbar t={trrackManager} />
-      <Button onClick={() => downloadScreenshot(ss.getNth(0), 'screenshot')}>
+      <Button
+        onClick={() =>
+          ss.getNth(0) ? downloadScreenshot(ss.getNth(0)!, 'screenshot') : null
+        }
+      >
         Download Latest Screenshot
       </Button>
       <Button

--- a/apps/react-trrack-example/src/app/App.tsx
+++ b/apps/react-trrack-example/src/app/App.tsx
@@ -13,8 +13,7 @@ import { TreeNode } from 'react-hyper-tree/dist/helpers/node';
 
 import { Navbar } from './components/Navbar';
 import { useTrrackTaskManager } from './store/trrack';
-import { useRef } from 'react';
-import { ScreenshotStream, downloadScreenshot } from '@trrack/core';
+import { downloadScreenshot } from '@trrack/core';
 
 function App() {
   const trrackManager = useTrrackTaskManager();
@@ -30,19 +29,17 @@ function App() {
   open(required.data, trrackManager.trrack.current.id);
 
   // Testing screenshot stream
-  const ss = useRef(new ScreenshotStream());
+  const ss = trrackManager.trrack.screenshots;
 
   return (
     <Box sx={{ height: '100vh', width: '100vw' }}>
-      <Navbar t={trrackManager} ss={ss.current} />
-      <Button
-        onClick={() => downloadScreenshot(ss.current.getNth(0), 'screenshot')}
-      >
+      <Navbar t={trrackManager} />
+      <Button onClick={() => downloadScreenshot(ss.getNth(0), 'screenshot')}>
         Download Latest Screenshot
       </Button>
       <Button
         onClick={() => {
-          ss.current.start();
+          ss.start();
         }}
       >
         Start recording

--- a/apps/react-trrack-example/src/app/components/Navbar.tsx
+++ b/apps/react-trrack-example/src/app/components/Navbar.tsx
@@ -21,7 +21,7 @@ export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
           <IconButton
             onClick={() => {
               trrack.apply('Increment counter', actions.incrementCounter(1));
-              ss.captureNextRepaint();
+              ss.delayCapture(100);
             }}
           >
             <AddIcon />
@@ -32,7 +32,7 @@ export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
           <IconButton
             onClick={() => {
               trrack.apply('Decrement counter', actions.decrementCounter(1));
-              ss.captureNextRepaint();
+              ss.delayCapture(100);
             }}
           >
             <RemoveIcon />

--- a/apps/react-trrack-example/src/app/components/Navbar.tsx
+++ b/apps/react-trrack-example/src/app/components/Navbar.tsx
@@ -8,7 +8,7 @@ import { Trrack } from '../store/trrack';
 import { Task } from '../store/types';
 import { ScreenshotStream } from '@trrack/core';
 
-export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
+export function Navbar({ t }: { t: Trrack }) {
   const { trrack, isAtLatest, isAtRoot, actions, counter } = t;
 
   return (
@@ -21,7 +21,6 @@ export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
           <IconButton
             onClick={() => {
               trrack.apply('Increment counter', actions.incrementCounter(1));
-              ss.delayCapture(100);
             }}
           >
             <AddIcon />
@@ -32,7 +31,6 @@ export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
           <IconButton
             onClick={() => {
               trrack.apply('Decrement counter', actions.decrementCounter(1));
-              ss.delayCapture(100);
             }}
           >
             <RemoveIcon />

--- a/apps/react-trrack-example/src/app/components/Navbar.tsx
+++ b/apps/react-trrack-example/src/app/components/Navbar.tsx
@@ -6,9 +6,9 @@ import { AppBar, Button, IconButton, Toolbar, Typography } from '@mui/material';
 
 import { Trrack } from '../store/trrack';
 import { Task } from '../store/types';
-import { ScreenshotStream} from '@trrack/core';
+import { ScreenshotStream } from '@trrack/core';
 
-export function Navbar({ t, ss }: { t: Trrack, ss: ScreenshotStream}) {
+export function Navbar({ t, ss }: { t: Trrack; ss: ScreenshotStream }) {
   const { trrack, isAtLatest, isAtRoot, actions, counter } = t;
 
   return (

--- a/apps/react-trrack-example/src/app/components/Navbar.tsx
+++ b/apps/react-trrack-example/src/app/components/Navbar.tsx
@@ -6,8 +6,9 @@ import { AppBar, Button, IconButton, Toolbar, Typography } from '@mui/material';
 
 import { Trrack } from '../store/trrack';
 import { Task } from '../store/types';
+import { ScreenshotStream} from '@trrack/core';
 
-export function Navbar({ t }: { t: Trrack }) {
+export function Navbar({ t, ss }: { t: Trrack, ss: ScreenshotStream}) {
   const { trrack, isAtLatest, isAtRoot, actions, counter } = t;
 
   return (
@@ -20,6 +21,7 @@ export function Navbar({ t }: { t: Trrack }) {
           <IconButton
             onClick={() => {
               trrack.apply('Increment counter', actions.incrementCounter(1));
+              ss.captureNextRepaint();
             }}
           >
             <AddIcon />
@@ -30,6 +32,7 @@ export function Navbar({ t }: { t: Trrack }) {
           <IconButton
             onClick={() => {
               trrack.apply('Decrement counter', actions.decrementCounter(1));
+              ss.captureNextRepaint();
             }}
           >
             <RemoveIcon />

--- a/apps/react-trrack-example/src/app/store/trrack.ts
+++ b/apps/react-trrack-example/src/app/store/trrack.ts
@@ -47,14 +47,15 @@ export function useTrrackTaskManager() {
         setCounter((c) => c + add);
         return {
           undo: {
-          type: 'decrement-counter',
-          payload: add,
-          meta: {
-            hasSideEffects: true,
+            type: 'decrement-counter',
+            payload: add,
+            meta: {
+              hasSideEffects: true,
+            },
           },
-        }
         };
-      }
+      },
+      true
     );
 
     const decrementCounter = reg.register(
@@ -63,14 +64,15 @@ export function useTrrackTaskManager() {
         setCounter((c) => c - sub);
         return {
           undo: {
-          type: 'increment-counter',
-          payload: sub,
-          meta: {
-            hasSideEffects: true,
+            type: 'increment-counter',
+            payload: sub,
+            meta: {
+              hasSideEffects: true,
+            },
           },
-        }
         };
-      }
+      },
+      true
     );
 
     return {

--- a/packages/core/src/provenance/index.ts
+++ b/packages/core/src/provenance/index.ts
@@ -2,3 +2,4 @@ export * from './trrack';
 export * from './trrack-config-opts';
 export * from './trrack-events';
 export * from './types';
+export * from './screenshot-stream';

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -1,4 +1,5 @@
 /**
+ * Factory function to create an instance of ScreenshotStream.
  * Captures and stores a sequence of screenshots of the current tab.
  * First, opens a MediaStream of the current tab, then can capture screenshots.
  * A screenshot can also be captured on-demand via capture() or after a delay via delayCapture().
@@ -7,88 +8,89 @@
  * will result in a memory leak.
  * All functions are bound to the class, so they can be passed as callbacks.
  */
-export class ScreenshotStream {
+export function intitializeScreenshotStream(
+    newScreenshotCallbacks?: ((frame: ImageData) => void)[]
+) {
+    /// Fields
     /**
      * Video element for capturing screenshots. Null if not started or stopped.
      */
-    private video: HTMLVideoElement | null = null;
+    let video: HTMLVideoElement | null = null;
 
     /**
      * Array of captured screenshots.
      */
-    private screenshots: ImageData[] = [];
+    const screenshots: ImageData[] = [];
 
     /**
      * ID of the timeout for delayCapture.
      * Null if no timeout is active.
      */
-    private timeout: NodeJS.Timeout | null = null;
+    let currentTimeout: NodeJS.Timeout | null = null;
 
     /**
-     * Optional callback to run after each screenshot is captured.
+     * Optional callbacks to run after each screenshot is captured.
      */
-    public newScreenshotCallback: ((frame: ImageData) => void) | null;
+    const newScreenshotCallback: ((frame: ImageData) => void)[] | null =
+        newScreenshotCallbacks ?? null;
 
-    /**
-     * Checks that the getDisplayMedia API is available
-     * and binds all functions to the class.
-     * @throws Error if the getDisplayMedia API is not available.
-     */
-    constructor(newScreenshotCallback?: (frame: ImageData) => void) {
-        if (!navigator.mediaDevices?.getDisplayMedia) {
-            throw new Error(
-                'MediaDevices API or getDisplayMedia() not available'
-            );
-        }
-
-        this.newScreenshotCallback = newScreenshotCallback ?? null;
-
-        this.capture = this.capture.bind(this);
-        this.stop = this.stop.bind(this);
-        this.delayCapture = this.delayCapture.bind(this);
-        this.push = this.push.bind(this);
-        this.getNth = this.getNth.bind(this);
-        this.count = this.count.bind(this);
-        this.getAll = this.getAll.bind(this);
-        this.start = this.start.bind(this);
+    /// Constructor
+    if (!navigator.mediaDevices?.getDisplayMedia) {
+        throw new Error('MediaDevices API or getDisplayMedia() not available');
     }
 
+    /// Methods
     /**
      * Starts the media stream needed to capture screenshots on-demand.
      * Will prompt the user for permission to capture the screen.
      * @throws Error if unable to start the recording; usually due to the user denying permission.
      * @param callback Optional callback to run after the stream is started.
      */
-    public async start(callback?: () => void): Promise<void> {
-        this.video = document.createElement('video');
-        this.video.autoplay = true;
-        this.video.muted = true;
-        this.video.playsInline = true;
-        this.video.style.pointerEvents = 'none';
-        this.video.style.visibility = 'hidden';
-        this.video.style.position = 'fixed';
-        this.video.style.top = '0';
-        this.video.style.left = '0';
+    async function start(callback?: () => void): Promise<void> {
+        video = document.createElement('video');
+        video.autoplay = true;
+        video.muted = true;
+        video.playsInline = true;
+        video.style.pointerEvents = 'none';
+        video.style.visibility = 'hidden';
+        video.style.position = 'fixed';
+        video.style.top = '0';
+        video.style.left = '0';
 
         try {
             await navigator.mediaDevices
-                .getDisplayMedia(/*displayMediaOptions*/)
+                // Need to cast because TS doesn't know about preferCurrentTab
+                .getDisplayMedia({
+                    preferCurrentTab: true,
+                } as DisplayMediaStreamOptions)
                 .then((stream) => {
-                    // TS is not confident that this.video is not null (but I am), so we need to check
-                    this.video ? (this.video.srcObject = stream) : null;
+                    // TS is not confident that video is not null (but I am), so we need to check
+                    video ? (video.srcObject = stream) : null;
                 });
         } catch (e) {
-            this.video = null;
+            video = null;
             throw new Error(`Unable to start recording: ${e}`);
         }
 
-        if (this.video.srcObject) {
+        if (video.srcObject) {
             // Needs to be in the DOM to capture screenshots
-            document.body.appendChild(this.video);
+            document.body.appendChild(video);
             callback ? callback() : null;
         } else {
             // I honestly don't know how we'd get here
             throw new Error('Unable to start recording; no stream available');
+        }
+    }
+
+    /**
+     * Pushes a screenshot frame to the screenshots array
+     * and invokes the newScreenshotCallbacks if available.
+     * @param frame - The screenshot frame to be pushed.
+     */
+    function push(frame: ImageData): void {
+        screenshots.push(frame);
+        for (const callback of newScreenshotCallback ?? []) {
+            callback(frame);
         }
     }
 
@@ -99,12 +101,12 @@ export class ScreenshotStream {
      * @throws Error if unable to get 2D rendering context.
      * @returns The captured screenshot.
      */
-    public capture(): ImageData {
-        if (!this.video) {
+    function capture(): ImageData {
+        if (!video) {
             throw new Error('Recording not started');
         }
 
-        const videoSettings = (this.video.srcObject as MediaStream)
+        const videoSettings = (video.srcObject as MediaStream)
             ?.getVideoTracks()[0]
             .getSettings();
         const canvas = document.createElement('canvas');
@@ -116,10 +118,10 @@ export class ScreenshotStream {
             // GetContext can return undefined and null (probably due to lack of browser support)
             throw new Error('Unable to get 2D rendering context');
         }
-        context.drawImage(this.video, 0, 0, canvas.width, canvas.height);
+        context.drawImage(video, 0, 0, canvas.width, canvas.height);
 
         const frame = context.getImageData(0, 0, canvas.width, canvas.height);
-        this.push(frame);
+        push(frame);
 
         canvas.remove();
         return frame;
@@ -131,15 +133,15 @@ export class ScreenshotStream {
      * and the old timeout is cleared and replaced with the new delay.
      * @param timeout The delay in milliseconds before capturing the screenshot.
      */
-    public delayCapture(timeout: number): void {
-        if (this.timeout) {
-            clearTimeout(this.timeout);
-            this.timeout = null;
-            this.capture();
+    function delayCapture(timeout: number): void {
+        if (currentTimeout) {
+            clearTimeout(currentTimeout);
+            currentTimeout = null;
+            capture();
         }
-        this.timeout = setTimeout(() => {
-            this.capture();
-            this.timeout = null;
+        currentTimeout = setTimeout(() => {
+            capture();
+            currentTimeout = null;
         }, timeout);
     }
 
@@ -147,52 +149,52 @@ export class ScreenshotStream {
      * Stops the media stream and removes the video element from the DOM.
      * Must be called to prevent memory leaks.
      */
-    public stop(): void {
-        if (this.video) {
-            this.video.srcObject = null;
-            this.video.remove();
-            this.video = null;
+    function stop(): void {
+        if (video) {
+            video.srcObject = null;
+            video.remove();
+            video = null;
         }
-    }
-
-    /**
-     * Pushes a screenshot frame to the `screenshots` array
-     * and invokes the `newScreenshotCallback` if available.
-     * @param frame - The screenshot frame to be pushed.
-     */
-    private push(frame: ImageData): void {
-        this.screenshots.push(frame);
-        this.newScreenshotCallback ? this.newScreenshotCallback(frame) : null;
     }
 
     /**
      * Returns the nth most recent screenshot in the array of stored screenshots.
      * @param n - The index of the screenshot to retrieve.
-     *  1 is the most recent screenshot, 0 is the least recent.
+     * 1 is the most recent screenshot, 0 is the least recent.
      * @returns The nth screenshot.
      */
-    public getNth(n: number): ImageData {
-        if (n < 0 || n >= this.screenshots.length) {
+    function getNth(n: number): ImageData {
+        if (n < 0 || n >= screenshots.length) {
             throw new Error(`Screenshot index out of bounds: ${n}`);
         }
-        return this.screenshots[this.screenshots.length - 1 - n];
+        return screenshots[screenshots.length - 1 - n];
     }
 
     /**
      * Returns the number of stored screenshots.
      * @returns The number of stored screenshots.
      */
-    public count(): number {
-        return this.screenshots.length;
+    function count(): number {
+        return screenshots.length;
     }
 
     /**
      * Returns a copy of the array of stored screenshots.
      * @returns The stored screenshots.
      */
-    public getAll(): ImageData[] {
-        return [...this.screenshots];
+    function getAll(): ImageData[] {
+        return [...screenshots];
     }
+
+    return {
+        start,
+        capture,
+        delayCapture,
+        stop,
+        getNth,
+        count,
+        getAll,
+    };
 }
 
 /**

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -95,6 +95,9 @@ export function intitializeScreenshotStream(
             // I honestly don't know how we'd get here
             throw new Error('Unable to start recording; no stream available');
         }
+
+        // We should capture initial state
+        capture();
     }
 
     /**
@@ -169,7 +172,11 @@ export function intitializeScreenshotStream(
      * @param n - The index of the screenshot to retrieve. 0 is the most recent.
      * @returns The nth screenshot.
      */
-    function getNth(n: number): ImageData {
+    function getNth(n: number): ImageData | null {
+        if (screenshots.length === 0) {
+            return null;
+        }
+
         if (n < 0 || n >= screenshots.length) {
             throw new Error(`Screenshot index out of bounds: ${n}`);
         }

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -59,19 +59,6 @@ export class ScreenshotStream {
         this.video.style.top = '0';
         this.video.style.left = '0';
 
-        /*const displayMediaOptions: DisplayMediaStreamOptions = {
-      video: {
-        //cursor: "never",
-        displaySurface: "browser"
-      },
-      audio: false,
-      // Below are explicit defaults because the actual varies by browser
-      // monitorTypeSurfaces: "exclude", // Don't offer whole-screen capture options
-      // preferCurrentTab: true,
-      // selfBrowserSurface: true,
-      // surfaceSwitching: "exclude",
-    };*/
-
         try {
             await navigator.mediaDevices
                 .getDisplayMedia(/*displayMediaOptions*/)

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -43,6 +43,18 @@ export function intitializeScreenshotStream(
 
     /// Methods
     /**
+     * Stops the media stream and removes the video element from the DOM.
+     * Must be called to prevent memory leaks.
+     */
+    function stop(): void {
+        if (video) {
+            video.srcObject = null;
+            video.remove();
+            video = null;
+        }
+    }
+
+    /**
      * Starts the media stream needed to capture screenshots on-demand.
      * Will prompt the user for permission to capture the screen.
      * @throws Error if unable to start the recording; usually due to the user denying permission.
@@ -68,6 +80,7 @@ export function intitializeScreenshotStream(
                 .then((stream) => {
                     // TS is not confident that video is not null (but I am), so we need to check
                     video ? (video.srcObject = stream) : null;
+                    stream.getVideoTracks()[0].onended = stop;
                 });
         } catch (e) {
             video = null;
@@ -148,18 +161,6 @@ export function intitializeScreenshotStream(
                 capture();
                 currentTimeout = null;
             }, timeout);
-        }
-    }
-
-    /**
-     * Stops the media stream and removes the video element from the DOM.
-     * Must be called to prevent memory leaks.
-     */
-    function stop(): void {
-        if (video) {
-            video.srcObject = null;
-            video.remove();
-            video = null;
         }
     }
 

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -111,6 +111,15 @@ export function intitializeScreenshotStream(): ScreenshotStream {
     }
 
     /**
+     * False if the MediaStream has not been initialized via start(), or has been stopped.
+     * True if we have a MediaStream and can capture screenshots.
+     * @returns Whether a screenshot can be captured.
+     */
+    function canCapture(): boolean {
+        return video !== null;
+    }
+
+    /**
      * Captures a screenshot and stores it in the screenshots array.
      * Also pushes the screenshot to the newScreenshotCallback if available.
      * @throws Error if recording has not been started.
@@ -118,7 +127,9 @@ export function intitializeScreenshotStream(): ScreenshotStream {
      * @returns The captured screenshot.
      */
     function capture(): ImageData {
-        if (!video) {
+        // We need the null check for ts, but canCapture() does that check already.
+        // We include canCapture() in case the implementation changes.
+        if (!canCapture() || !video) {
             throw new Error('Recording not started');
         }
 
@@ -198,14 +209,6 @@ export function intitializeScreenshotStream(): ScreenshotStream {
     }
 
     /**
-     * Returns whether the screenshot stream is currently recording.
-     * @returns Whether the screenshot stream is currently recording.
-     */
-    function isRecording(): boolean {
-        return video !== null;
-    }
-
-    /**
      * Registers a listener to be called when a new screenshot is captured.
      * @param listener - The listener to be called when a new screenshot is captured.
      * @returns A function to remove the listener.
@@ -230,7 +233,7 @@ export function intitializeScreenshotStream(): ScreenshotStream {
         getNth,
         count,
         getAll,
-        isRecording,
+        canCapture: canCapture,
         registerScreenshotListener,
     };
 }

--- a/packages/core/src/provenance/screenshot-stream.ts
+++ b/packages/core/src/provenance/screenshot-stream.ts
@@ -1,0 +1,220 @@
+/**
+ * Captures and stores a sequence of screenshots of the current tab.
+ * First, opens a MediaStream of the current tab, then captures screenshots
+ * on repaints after captureNextRepaint() is called.
+ * A screenshot can also be captured on-demand via capture().
+ * Requires browser permissions to capture screen.
+ * Must be activated via start() and deactivated via stop(); failure to stop
+ * will result in a memory leak.
+ */
+export class ScreenshotStream {
+    /**
+     * Video element for capturing screenshots. Null if not started or stopped.
+     */
+    private video: HTMLVideoElement | null = null;
+
+    /**
+     * Array of captured screenshots.
+     */
+    private screenshots: ImageData[] = [];
+
+    /**
+     * Optional callback to run after each screenshot is captured.
+     */
+    public newScreenshotCallback: ((frame: ImageData) => void) | null;
+
+    /**
+     * Binds capture, stop, and captureNextRepaint to the class.
+     * @throws Error if the getDisplayMedia API is not available.
+     */
+    constructor(newScreenshotCallback?: (frame: ImageData) => void) {
+        if (!navigator.mediaDevices?.getDisplayMedia) {
+            throw new Error(
+                'MediaDevices API or getDisplayMedia() not available'
+            );
+        }
+
+        this.newScreenshotCallback = newScreenshotCallback ?? null;
+
+        // We need to functions that can be used as callbacks to the class
+        this.capture = this.capture.bind(this);
+        this.stop = this.stop.bind(this);
+        this.captureNextRepaint = this.captureNextRepaint.bind(this);
+    }
+
+    /**
+     * Starts the media stream needed to capture screenshots on-demand.
+     * Will prompt the user for permission to capture the screen.
+     * @throws Error if unable to start the recording; usually due to the user denying permission.
+     * @param callback Optional callback to run after the stream is started.
+     */
+    public async start(callback?: () => void): Promise<void> {
+        this.video = document.createElement('video');
+        this.video.autoplay = true;
+        this.video.muted = true;
+        this.video.playsInline = true;
+        this.video.style.pointerEvents = 'none';
+        this.video.style.visibility = 'hidden';
+        this.video.style.position = 'fixed';
+        this.video.style.top = '0';
+        this.video.style.left = '0';
+
+        /*const displayMediaOptions: DisplayMediaStreamOptions = {
+      video: {
+        //cursor: "never",
+        displaySurface: "browser"
+      },
+      audio: false,
+      // Below are explicit defaults because the actual varies by browser
+      // monitorTypeSurfaces: "exclude", // Don't offer whole-screen capture options
+      // preferCurrentTab: true,
+      // selfBrowserSurface: true,
+      // surfaceSwitching: "exclude",
+    };*/
+
+        try {
+            await navigator.mediaDevices
+                .getDisplayMedia(/*displayMediaOptions*/)
+                .then((stream) => {
+                    // TS is not confident that this.video is not null (but I am), so we need to check
+                    this.video ? (this.video.srcObject = stream) : null;
+                });
+        } catch (e) {
+            this.video = null;
+            throw new Error(`Unable to start recording: ${e}`);
+        }
+
+        if (this.video.srcObject) {
+            // Needs to be in the DOM to capture screenshots
+            document.body.appendChild(this.video);
+            callback ? callback() : null;
+        } else {
+            // I honestly don't know how we'd get here
+            throw new Error('Unable to start recording; no stream available');
+        }
+    }
+
+    /**
+     * Captures a screenshot and stores it in the screenshots array.
+     * Also pushes the screenshot to the newScreenshotCallback if available.
+     * Bound to the class in the constructor.
+     * @throws Error if recording has not been started.
+     * @throws Error if unable to get 2D rendering context.
+     * @returns The captured screenshot.
+     */
+    public capture(): ImageData {
+        if (!this.video) {
+            throw new Error('Recording not started');
+        }
+
+        const videoSettings = (this.video.srcObject as MediaStream)
+            ?.getVideoTracks()[0]
+            .getSettings();
+        const canvas = document.createElement('canvas');
+        canvas.width = videoSettings.width || 0;
+        canvas.height = videoSettings.height || 0;
+
+        const context = canvas.getContext('2d');
+        if (!context) {
+            // GetContext can return undefined and null (probably due to lack of browser support)
+            throw new Error('Unable to get 2D rendering context');
+        }
+        context.drawImage(this.video, 0, 0, canvas.width, canvas.height);
+
+        const frame = context.getImageData(0, 0, canvas.width, canvas.height);
+        this.push(frame);
+
+        canvas.remove();
+        return frame;
+    }
+
+    /**
+     * Captures a screenshot after the next repaint and adds it to the screenshot array.
+     * Useful if you want to screenshot a state change that you've just processed.
+     * Bound to the class in the constructor.
+     */
+    public captureNextRepaint(): void {
+        requestAnimationFrame(() => {
+            const mc = new MessageChannel();
+            mc.port1.onmessage = this.capture;
+            mc.port2.postMessage(undefined);
+        });
+    }
+
+    /**
+     * Stops the media stream and removes the video element from the DOM.
+     * Must be called to prevent memory leaks.
+     * Bound to the class in the constructor.
+     */
+    public stop(): void {
+        if (this.video) {
+            this.video.srcObject = null;
+            this.video.remove();
+            this.video = null;
+        }
+    }
+
+    /**
+     * Pushes a screenshot frame to the `screenshots` array
+     * and invokes the `newScreenshotCallback` if available.
+     * @param frame - The screenshot frame to be pushed.
+     */
+    private push(frame: ImageData): void {
+        this.screenshots.push(frame);
+        this.newScreenshotCallback ? this.newScreenshotCallback(frame) : null;
+    }
+
+    /**
+     * Returns the nth most recent screenshot in the array of stored screenshots.
+     * @param n - The index of the screenshot to retrieve.
+     *  1 is the most recent screenshot, 0 is the least recent.
+     * @returns The nth screenshot.
+     */
+    public getNth(n: number): ImageData {
+        if (n < 0 || n >= this.screenshots.length) {
+            throw new Error(`Screenshot index out of bounds: ${n}`);
+        }
+        return this.screenshots[this.screenshots.length - 1 - n];
+    }
+
+    /**
+     * Returns the number of stored screenshots.
+     * @returns The number of stored screenshots.
+     */
+    public count(): number {
+        return this.screenshots.length;
+    }
+
+    /**
+     * Returns a copy of the array of stored screenshots.
+     * @returns The stored screenshots.
+     */
+    public getAll(): ImageData[] {
+        return [...this.screenshots];
+    }
+}
+
+/**
+ * Downloads a screenshot as a PNG file.
+ * @param frame - The screenshot frame to download.
+ * @param name - The name of the file to download.
+ */
+export function downloadScreenshot(frame: ImageData, name: string): void {
+    const canvas = document.createElement('canvas');
+    canvas.width = frame.width;
+    canvas.height = frame.height;
+
+    const context = canvas.getContext('2d');
+    if (!context) {
+        throw new Error('Unable to get 2D rendering context');
+    }
+    context.putImageData(frame, 0, 0);
+
+    const a = document.createElement('a');
+    a.href = canvas.toDataURL();
+    a.download = name;
+    a.click();
+
+    canvas.remove();
+    a.remove();
+}

--- a/packages/core/src/provenance/trrack.ts
+++ b/packages/core/src/provenance/trrack.ts
@@ -307,7 +307,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
                 });
             }
 
-            if (screenshots.isRecording() && action.triggersScreenshot)
+            if (screenshots.canCapture() && action.triggersScreenshot)
                 screenshots.delayCapture(action.transitionTime);
         },
         async to(node: NodeId) {
@@ -327,7 +327,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
             for (let i = 0; i < path.length - 1; ++i) {
                 const currentNode = getNode(path[i]);
 
-                if (screenshots.isRecording()) {
+                if (screenshots.canCapture()) {
                     const action = registry.get(currentNode.event);
                     if (
                         action.triggersScreenshot &&
@@ -359,7 +359,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
 
             graph.update(graph.changeCurrent(node));
 
-            if (screenshots.isRecording() && maxTimer >= 0) {
+            if (screenshots.canCapture() && maxTimer >= 0) {
                 screenshots.delayCapture(maxTimer);
             }
 
@@ -396,7 +396,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
             });
         },
         done() {
-            if (screenshots.isRecording()) screenshots.stop();
+            if (screenshots.canCapture()) screenshots.stop();
             console.log('Setup later for URL sharing.');
         },
         tree() {

--- a/packages/core/src/provenance/trrack.ts
+++ b/packages/core/src/provenance/trrack.ts
@@ -24,6 +24,7 @@ import {
 } from '../registry';
 import { ConfigureTrrackOptions } from './trrack-config-opts';
 import { TrrackEvents } from './trrack-events';
+import { intitializeScreenshotStream } from './screenshot-stream';
 
 function getState<State, Event extends string>(
     node: ProvenanceNode<State, Event>,
@@ -78,6 +79,12 @@ export function initializeTrrack<State = any, Event extends string = string>({
     const eventManager = initEventManager();
     const graph = initializeProvenanceGraph<State, Event>(initialState);
 
+    /**
+     * Retrieves a node from the graph based on its ID.
+     *
+     * @param id - The ID of the node.
+     * @returns The node with the specified ID.
+     */
     function getNode(id: NodeId) {
         return graph.backend.nodes[id];
     }
@@ -89,6 +96,8 @@ export function initializeTrrack<State = any, Event extends string = string>({
     eventManager.listen(TrrackEvents.TRAVERSAL_END, () => {
         isTraversing = false;
     });
+
+    const screenshots = intitializeScreenshotStream();
 
     const metadata = {
         add(
@@ -297,6 +306,9 @@ export function initializeTrrack<State = any, Event extends string = string>({
                     eventType: action.config.eventType as Event,
                 });
             }
+
+            if (screenshots.isRecording() && action.triggersScreenshot)
+                screenshots.delayCapture(action.transitionTime);
         },
         async to(node: NodeId) {
             eventManager.fire(TrrackEvents.TRAVERSAL_START);
@@ -308,9 +320,22 @@ export function initializeTrrack<State = any, Event extends string = string>({
             );
 
             const sideEffectsToApply: Array<PayloadAction<any, any>> = [];
+            // Only take a screenshot if we find a node in the path that triggers one. Use
+            // the max transition timer encountered when screenshotting
+            let maxTimer = -1;
 
             for (let i = 0; i < path.length - 1; ++i) {
                 const currentNode = getNode(path[i]);
+
+                if (screenshots.isRecording()) {
+                    const action = registry.get(currentNode.event);
+                    if (
+                        action.triggersScreenshot &&
+                        action.transitionTime > maxTimer
+                    )
+                        maxTimer = action.transitionTime;
+                }
+
                 const nextNode = getNode(path[i + 1]);
 
                 const isUndo = isNextNodeUp(currentNode, nextNode);
@@ -333,6 +358,10 @@ export function initializeTrrack<State = any, Event extends string = string>({
             }
 
             graph.update(graph.changeCurrent(node));
+
+            if (screenshots.isRecording() && maxTimer >= 0) {
+                screenshots.delayCapture(maxTimer);
+            }
 
             eventManager.fire(TrrackEvents.TRAVERSAL_END);
         },
@@ -367,6 +396,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
             });
         },
         done() {
+            if (screenshots.isRecording()) screenshots.stop();
             console.log('Setup later for URL sharing.');
         },
         tree() {
@@ -401,6 +431,7 @@ export function initializeTrrack<State = any, Event extends string = string>({
         artifact,
         annotations,
         bookmarks,
+        screenshots,
     };
 }
 

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -22,6 +22,16 @@ export type RecordActionArgs<State, Event extends string> = {
     onlySideEffects?: boolean;
 };
 
+export interface ScreenshotStream {
+    start(): void;
+    capture(): void;
+    delayCapture(): void;
+    stop(): void;
+    getNth(n: number): ImageData;
+    count(): number;
+    getAll(): ImageData[];
+}
+
 export interface Trrack<State, Event extends string> {
     registry: Registry<Event>;
     isTraversing: boolean;

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -23,14 +23,51 @@ export type RecordActionArgs<State, Event extends string> = {
 };
 
 export interface ScreenshotStream {
+    /**
+     * Presents a dialog to the user to record the current tab, begins a video stream,
+     * and enables the capture of screenshots.
+     */
     start(): void;
+    /**
+     * Immediately captures a screenshot from the video stream.
+     * @returns The captured screenshot.
+     */
     capture(): ImageData;
+    /**
+     * Captures a screenshot after a delay.
+     * @param timeout - The amount of time to delay the capture in ms.
+     */
     delayCapture(timeout: number): void;
+    /**
+     * Stops the video stream and screenshot capture.
+     */
     stop(): void;
+    /**
+     * Returns the nth most recent screenshot in the array of stored screenshots.
+     * @param n - The index of the screenshot to retrieve. 0 is the most recent.
+     * @returns The nth screenshot.
+     */
     getNth(n: number): ImageData | null;
+    /**
+     * Returns the number of stored screenshots.
+     */
     count(): number;
+    /**
+     * Returns a copy of the array of stored screenshots.
+     */
     getAll(): ImageData[];
+    /**
+     * Returns whether the screenshot stream is currently recording.
+     */
     isRecording(): boolean;
+    /**
+     * Registers a listener to be called when a screenshot is captured.
+     * @param listener - The listener to register.
+     * @returns A function to unregister the listener.
+     */
+    registerScreenshotListener(
+        listener: (image: ImageData) => void
+    ): () => void;
 }
 
 export interface Trrack<State, Event extends string> {

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -27,7 +27,7 @@ export interface ScreenshotStream {
     capture(): ImageData;
     delayCapture(timeout: number): void;
     stop(): void;
-    getNth(n: number): ImageData;
+    getNth(n: number): ImageData | null;
     count(): number;
     getAll(): ImageData[];
     isRecording(): boolean;

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -24,12 +24,13 @@ export type RecordActionArgs<State, Event extends string> = {
 
 export interface ScreenshotStream {
     start(): void;
-    capture(): void;
-    delayCapture(): void;
+    capture(): ImageData;
+    delayCapture(timeout: number): void;
     stop(): void;
     getNth(n: number): ImageData;
     count(): number;
     getAll(): ImageData[];
+    isRecording(): boolean;
 }
 
 export interface Trrack<State, Event extends string> {
@@ -88,4 +89,9 @@ export interface Trrack<State, Event extends string> {
     exportObject(): ProvenanceGraph<State, Event>;
     import(graphString: string): void;
     importObject(graph: ProvenanceGraph<State, Event>): void;
+    /**
+     * Interface for capturing screenshots. When activated,
+     * captures a screenshot after certain actions fire.
+     */
+    screenshots: ScreenshotStream;
 }

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -1,5 +1,5 @@
 import { PayloadAction } from '@reduxjs/toolkit';
-import { NodeId } from '@trrack/core';
+import { NodeId } from '../graph/components/node';
 import {
     Artifact,
     CurrentChangeHandler,

--- a/packages/core/src/provenance/types.ts
+++ b/packages/core/src/provenance/types.ts
@@ -57,9 +57,9 @@ export interface ScreenshotStream {
      */
     getAll(): ImageData[];
     /**
-     * Returns whether the screenshot stream is currently recording.
+     * @returns whether capturing is allowed. Generally is false before start() is called and after stop() is called.
      */
-    isRecording(): boolean;
+    canCapture(): boolean;
     /**
      * Registers a listener to be called when a screenshot is captured.
      * @param listener - The listener to register.

--- a/packages/core/src/registry/reg.ts
+++ b/packages/core/src/registry/reg.ts
@@ -13,31 +13,86 @@ import {
 
 enablePatches();
 
-
+/**
+ * Represents a registered trrack action.
+ */
 type TrrackActionRegisteredObject = {
-    func: TrrackActionFunction<any, any, any, any> | ProduceWrappedStateChangeFunction<any>;
+    func:
+        | TrrackActionFunction<any, any, any, any>
+        | ProduceWrappedStateChangeFunction<any>;
     config: TrrackActionConfig<any, any>;
 };
 
-function prepareAction(action: TrrackActionFunction<any, any, any, any> | StateChangeFunction<any, any>) {
-    return action.length === 2 ? produce(action) as unknown as ProduceWrappedStateChangeFunction<any> : action as TrrackActionFunction<any, any, any, any>;
+/**
+ * Prepares an action function for registration by wrapping it with the `produce` function if it has two arguments.
+ * @param action - The action function to prepare.
+ * @returns The prepared action function.
+ */
+function prepareAction(
+    action:
+        | TrrackActionFunction<any, any, any, any>
+        | StateChangeFunction<any, any>
+) {
+    return action.length === 2
+        ? (produce(action) as unknown as ProduceWrappedStateChangeFunction<any>)
+        : (action as TrrackActionFunction<any, any, any, any>);
 }
 
+/**
+ * Represents a registry for managing trrack actions.
+ */
 export class Registry<Event extends string> {
+    /**
+     * Creates a new instance of the `Registry` class.
+     * @returns A new instance of the `Registry` class.
+     */
     static create<Event extends string>(): Registry<Event> {
         return new Registry<Event>();
     }
 
+    /**
+     * The registry for storing TrrackActionRegisteredObject objects.
+     */
     private registry: Map<string, TrrackActionRegisteredObject>;
 
+    /**
+     * Creates a new instance of the `Registry` class.
+     */
     private constructor() {
         this.registry = new Map();
     }
 
+    /**
+     * Checks if an action with the specified name is registered in the registry.
+     * @param name - The name of the action to check.
+     * @returns `true` if the action is registered, `false` otherwise.
+     */
     has(name: string) {
         return this.registry.has(name);
     }
 
+    /**
+     * Registers a new action in the registry.
+     *
+     * @template DoActionType - The type of the action to be registered.
+     * @template UndoActionType - The type of the undo action associated with the registered action.
+     * @template DoActionPayload - The payload type for the action.
+     * @template UndoActionPayload - The payload type for the undo action.
+     * @template State - The state type.
+     *
+     * @param {DoActionType} type - The type of the action.
+     * @param {TrrackActionFunction<DoActionType, UndoActionType, UndoActionPayload, DoActionPayload>
+     *  | StateChangeFunction<State, DoActionPayload>} actionFunction
+     *  - The action function or state change function associated with the action.
+     * @param {Object} [config] - Optional configuration for the action.
+     * @param {Event} [config.eventType] - The event type associated with the action.
+     * @param {Label | LabelGenerator<DoActionPayload>} [config.label] - The label or label generator for the action.
+     *
+     * @throws {Error} If the action function has more than two arguments.
+     * @throws {Error} If the action is already registered.
+     *
+     * @returns {Action<DoActionPayload>} The created action.
+     */
     register<
         DoActionType extends string,
         UndoActionType extends string,
@@ -46,25 +101,30 @@ export class Registry<Event extends string> {
         State = any
     >(
         type: DoActionType,
-        actionFunction: TrrackActionFunction<
-            DoActionType,
-            UndoActionType,
-            UndoActionPayload,
-            DoActionPayload
-        > | StateChangeFunction<State, DoActionPayload>,
+        actionFunction:
+            | TrrackActionFunction<
+                  DoActionType,
+                  UndoActionType,
+                  UndoActionPayload,
+                  DoActionPayload
+              >
+            | StateChangeFunction<State, DoActionPayload>,
         config?: {
             eventType: Event;
-            label: Label | LabelGenerator<DoActionPayload>
+            label: Label | LabelGenerator<DoActionPayload>;
         }
     ) {
         const isState = actionFunction.length === 2;
 
         if (actionFunction.length > 2)
-            throw new Error('Incorrect action function signature. Action function can only have two arguments at most!');
+            throw new Error(
+                'Incorrect action function signature. Action function can only have two arguments at most!'
+            );
 
         if (this.has(type)) throw new Error(`Already registered: ${type}`);
 
-        const { label = type, eventType = type as unknown as Event } = config || {};
+        const { label = type, eventType = type as unknown as Event } =
+            config || {};
 
         this.registry.set(type, {
             func: prepareAction(actionFunction),
@@ -81,6 +141,12 @@ export class Registry<Event extends string> {
         return createAction<DoActionPayload>(type);
     }
 
+    /**
+     * Gets the registered action with the specified type.
+     * @param type - The type of the action to get.
+     * @returns The registered action.
+     * @throws An error if the action is not registered.
+     */
     get(type: string) {
         const action = this.registry.get(type);
 


### PR DESCRIPTION
This adds an API for taking screenshots of the current tab manually and when certain actions are trracked. 

The `ScreenshotStream` interface defines an API for capturing screenshots. Screenshots are taken via the `MediaDevices` API, specifically the `getDisplayMedia()` function. After starting a stream of frames from the browser, individual shots can be saved at any point, either manually or when triggering actions fire.

The `Registry` API has been updated to add 2 fields: `triggersScreenshot`, which defines whether an action should fire a screenshot, and `transitionTime`, which defines how long it takes for an action to be reflected in the visualization and therefore the delay before screenshotting.

The `Trrack` object has been updated with a new field, `screenshots`, an instance of `ScreenshotStream`. This exposes methods for starting capture (necessary to obtain a stream of frames from the browser), which asks the user for permission to share the current tab. There are also methods to capture a screenshot immediately, capture after a delay, stop the `MediaStream` that provides frames from the screenshare, and get saved screenshots. The current implementation of ScreenshotStream saves all captured screenshots to an array. The Trrack object does not take screenshots due to actions with `triggersScreenshot = true` until the ScreenshotStream has been started.